### PR TITLE
Add a jekyll config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
+# Ignore built jekyll site files
 _site/
 
+# Ignore jekyll cache files
+.jekyll-cache/

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,6 @@
 # Global configuration
 timezone: America/New_York
+exclude: ['CNAME']
 
 # Serve Configuration
 port: 8080

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,20 @@
+---
+# Global configuration
+source: ./
+destination: ./_site
+timezone: America/New_York
+encoding: utf-8
+
+# Serve Configuration
+port: 8080
+host: localhost
+
+# Front-Matter defaults
+defaults:
+  -
+    scope:
+      path: ""
+      type: "pages"
+    values:
+      author: ""
+    

--- a/_config.yml
+++ b/_config.yml
@@ -1,20 +1,6 @@
----
 # Global configuration
-source: ./
-destination: ./_site
 timezone: America/New_York
-encoding: utf-8
 
 # Serve Configuration
 port: 8080
 host: localhost
-
-# Front-Matter defaults
-defaults:
-  -
-    scope:
-      path: ""
-      type: "pages"
-    values:
-      author: ""
-    


### PR DESCRIPTION
Add a jekyll config file for defining build parameters, and forcing serve commands to default to port 8080 and host localhost for consistency