### PR TITLE
Fix tab bar icon not loading

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,9 +2,9 @@
 <html lang="en">
     <head> 
 	    <meta charset="UTF-8">
-	    <link rel="icon" type="image/png" href="images/favicon.ico">
+	    <link rel="icon" type="image/svg-xml" href="images/shieldNoText.svg">
 	    <title>CUCTF</title>
-	    <link rel="shortcut icon" href="images/cuctf-small.png">
+	    <link rel="shortcut icon" href="images/shieldNoText.svg">
 	    <meta name="description" content="{{ page.description }}">
 	    <meta name="keywords" content="{{ page.keywords }}">
 	    <meta name="author" content="{{ page.author }}">


### PR DESCRIPTION
The icon in the html header is currently set to point to `images/favicon.ico`, which does not work as the element is set to `type="image/png"`. Similarly, the shortcut-icon property is set to `images/cuctf-small.png` which also will not work since it is not a `.ico` file. I figure the two just got mixed up. Switching the two causes the icons to render properly.