### PR TITLE
Make headings consistent

### DIFF
--- a/cuctf_2019.html
+++ b/cuctf_2019.html
@@ -6,6 +6,7 @@ keywords:
 author:
 ---
 <div class="container white-text" id="past">
+  <h1 class="text-accent-4 center">CUCTF 2019</h1>
   <div class="row">
     <div class="col s12 m6">
       <img src="/public/images/2019/Trophies.png" alt="A line of wooden trophies sits on table next to a CUCTF banner with the subheading sponsored by SecureWorks Adversary Group.">

--- a/faqs.html
+++ b/faqs.html
@@ -5,40 +5,32 @@ description: Frequently asked questions page
 keywords:
 author:
 ---
-<h1 class="center">Frequently Asked Questions</h1>
 <div class="container white-text">
-    <ul class="collapsible black">
-        <li>
-            <div class="collapsible-header black clemson-orange-text">Where is the event being held?</div>
-            <div class="collapsible-body"><span>The even is being held at Clemson University's Watt Family Innovation
-                    Center. The address is
-                    <a rel="external noopener" href="https://goo.gl/maps/XZTw4u9Mu72V6P7s6" target="_blank">
-                        405 S Palmetto Blvd, Clemson, SC 29634</a>.</span></div>
-        </li>
-        <li>
-            <div class="collapsible-header black clemson-orange-text">When is the event?</div>
-            <div class="collapsible-body"><span>CUCTF is taking place October 3rd, 2020.</span></div>
-        </li>
-        <li>
-            <div class="collapsible-header black clemson-orange-text">Who is elgible for the event?</div>
-            <div class="collapsible-body"><span>Only university and college teams are eligible for CUCTF.</span></div>
-        </li>
-        <li>
-            <div class="collapsible-header black clemson-orange-text">How many people are allowed on a team?</div>
-            <div class="collapsible-body"><span>You may have up to 4 members on a competing team and, optionally, up to
-                    2 members for the CTF Bootcamp.</span></div>
-        </li>
-        <li>
-            <div class="collapsible-header black clemson-orange-text">Do we get anything for winning?</div>
-            <div class="collapsible-body"><span>Yes! We'll announce the prizes and update this FAQ once we have more
-                    information on awards.</span></div>
-        </li>
-        <li>
-            <div class="collapsible-header black clemson-orange-text">Do we need a faculty/staff advisor?</div>
-            <div class="collapsible-body"><span>An advisor is not necessary to participate in CUCTF but having an
-                    advisor attend the event is strongly encouraged. They will have the opportunity to participate in
-                    a few activities, including the CTF Bootcamp, during the competition.</span>
-            </div>
-        </li>
-    </ul>
+  <h1 class="text-accent-4 center">Frequently Asked Questions</h1>
+  <ul class="collapsible black">
+    <li>
+      <div class="collapsible-header black clemson-orange-text">Where is the event being held?</div>
+      <div class="collapsible-body"><span>The even is being held at Clemson University's Watt Family Innovation Center. The address is <a rel="external noopener" href="https://goo.gl/maps/XZTw4u9Mu72V6P7s6" target="_blank">405 S Palmetto Blvd, Clemson, SC 29634</a>.</span></div>
+    </li>
+    <li>
+      <div class="collapsible-header black clemson-orange-text">When is the event?</div>
+      <div class="collapsible-body"><span>CUCTF is taking place October 3rd, 2020.</span></div>
+    </li>
+    <li>
+      <div class="collapsible-header black clemson-orange-text">Who is elgible for the event?</div>
+      <div class="collapsible-body"><span>Only university and college teams are eligible for CUCTF.</span></div>
+    </li>
+    <li>
+      <div class="collapsible-header black clemson-orange-text">How many people are allowed on a team?</div>
+      <div class="collapsible-body"><span>You may have up to 4 members on a competing team and, optionally, up to 2 members for the CTF Bootcamp.</span></div>
+    </li>
+    <li>
+      <div class="collapsible-header black clemson-orange-text">Do we get anything for winning?</div>
+      <div class="collapsible-body"><span>Yes! We'll announce the prizes and update this FAQ once we have more information on awards.</span></div>
+    </li>
+    <li>
+      <div class="collapsible-header black clemson-orange-text">Do we need a faculty/staff advisor?</div>
+      <div class="collapsible-body"><span>An advisor is not necessary to participate in CUCTF but having an advisor attend the event is strongly encouraged. They will have the opportunity to participate in a few activities, including the CTF Bootcamp, during the competition.</span></div>
+    </li>
+  </ul>
 </div>

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -74,12 +74,12 @@ p.json {
   font-size: 24px;
 }
 
-iframe.register {
+#register iframe {
   display: block;
   margin-left: auto;
   margin-right: auto;
-  height: 1050px;
-  width: 90vw;
+  height: 1550px;
+  width: 100%;
   border: none;
 }
 

--- a/register.html
+++ b/register.html
@@ -5,4 +5,7 @@ description: Registration page
 keywords:
 author:
 ---
-  <iframe class="register" src="https://docs.google.com/forms/d/e/1FAIpQLSdk7eF5DsH6i9Lq-N6zvnL3b85wxIHbqWj7mwN6ovx0Lcuusw/viewform?embedded=true"></iframe>
+<div class="container" id="register">
+  <h1 class="text-accent-4 center">Register</h1>
+  <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSdk7eF5DsH6i9Lq-N6zvnL3b85wxIHbqWj7mwN6ovx0Lcuusw/viewform?embedded=true"></iframe>
+</div>

--- a/sponsors.html
+++ b/sponsors.html
@@ -7,7 +7,7 @@ author:
 ---
 
 <div class="container white-text">
-  <h2 class="center">Sponsor</h2>
+  <h1 class="text-accent-4 center">Sponsor</h1>
   <h5>Sponsoring CUCTF is a great way for you to connect with top cybersecurity-focused students studying at various
     universities across the southeast.</h5>
   <h3 class="clemson-orange-text">By sponsoring, you can...</h3>

--- a/team.html
+++ b/team.html
@@ -6,7 +6,7 @@ keywords:
 author:
 ---
 <div class="container" id="team">
-  <h1 class="clemson-orange-text text-accent-4 center">Our Team</h1>
+  <h1 class="text-accent-4 center">Our Team</h1>
   <div class="row">
     <div class="col m12 l6 xl4">
       <div class="card black">


### PR DESCRIPTION
I made the headings consistent per the discussion in #19. They are all now `<h1 class="text-accent-4 center">` and properly contained. I also threw in registration page fixes because it had a few style/placement issues (not centered, double scroll bars, no heading).

This PR includes the changes from #19.

Closes #19