### PR TITLE
Fix sponsor image centering and SpectreOps width/disappearing 

### DIFF
--- a/2019.html
+++ b/2019.html
@@ -80,22 +80,22 @@ title: 2019
   <div class="center" id="sponsors">
     <h2 class="clemson-orange-text text-accent-4 center">Level 2 Sponsors</h2>
     <div class="row white">
-      <div class="col m12 l12 xl4">
+      <div class="col s12 m12 l12 xl4">
         <a href="https://www.crowdstrike.com/">
           <img src="/public/images/2019/sponsors/crowdstrike.png" class="sponsor-img" alt="CrowdStrike">
         </a>
       </div>
-      <div class="col m12 l12 xl4">
+      <div class="col s12 m12 l12 xl4">
         <a href="https://www.ally.com/">
           <img src="/public/images/2019/sponsors/ally.png" class="sponsor-img" alt="Ally">
         </a>
       </div>
-      <div class="col m12 l12 xl4">
+      <div class="col s12 m12 l12 xl4">
         <a href="https://specterops.io/">
           <img src="/public/images/2019/sponsors/specterops.svg" class="sponsor-img" alt="SpecterOps">
         </a>
       </div>
-      <div class="col m12 l12 xl12">
+      <div class="col s12 m12 l12 xl12">
         <a href="https://www.fireeye.com/company.html">
           <img src="/public/images/2019/sponsors/fireeye.png" class="sponsor-img" alt="FireEye">
         </a>


### PR DESCRIPTION
Closes #30 

Just adds the specifier "s12" to the column classes for the sponsor images.

